### PR TITLE
Fixes node-delete's delete-node call

### DIFF
--- a/src/wrapper.lisp
+++ b/src/wrapper.lisp
@@ -46,7 +46,7 @@
   (:method ((node integer) &key cascade)
     (when cascade
       (mapc #'relationship-delete (node-relationships node)))
-    (delete-node :node-id node)))
+    (delete-node :nodeid node)))
 
 (defgeneric node-properties (node)
   (:documentation "Returns plist of properties of the node.")


### PR DESCRIPTION
The keyword ":node-id" isn't what is used with the definition of DELETE-NODE; it should be ":nodeid".